### PR TITLE
Small fixes for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ screen.psd
 __pycache__
 automatic_testfonts
 *.pyc
+.DS_Store

--- a/DesignSpaceEditor.roboFontExt/lib/designSpaceDocument.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designSpaceDocument.py
@@ -407,7 +407,7 @@ class BaseDocWriter(object):
             instanceElement.attrib['stylename'] = instanceObject.styleName
         # add localisations
         if instanceObject.localisedStyleName:
-            languageCodes = instanceObject.localisedStyleName.keys()
+            languageCodes = list(instanceObject.localisedStyleName.keys())
             languageCodes.sort()
             for code in languageCodes:
                 if code == "en": continue # already stored in the element attribute
@@ -416,7 +416,7 @@ class BaseDocWriter(object):
                 localisedStyleNameElement.text = instanceObject.getStyleName(code)
                 instanceElement.append(localisedStyleNameElement)
         if instanceObject.localisedFamilyName:
-            languageCodes = instanceObject.localisedFamilyName.keys()
+            languageCodes = list(instanceObject.localisedFamilyName.keys())
             languageCodes.sort()
             for code in languageCodes:
                 if code == "en": continue # already stored in the element attribute
@@ -425,7 +425,7 @@ class BaseDocWriter(object):
                 localisedFamilyNameElement.text = instanceObject.getFamilyName(code)
                 instanceElement.append(localisedFamilyNameElement)
         if instanceObject.localisedStyleMapStyleName:
-            languageCodes = instanceObject.localisedStyleMapStyleName.keys()
+            languageCodes = list(instanceObject.localisedStyleMapStyleName.keys())
             languageCodes.sort()
             for code in languageCodes:
                 if code == "en": continue
@@ -434,7 +434,7 @@ class BaseDocWriter(object):
                 localisedStyleMapStyleNameElement.text = instanceObject.getStyleMapStyleName(code)
                 instanceElement.append(localisedStyleMapStyleNameElement)
         if instanceObject.localisedStyleMapFamilyName:
-            languageCodes = instanceObject.localisedStyleMapFamilyName.keys()
+            languageCodes = list(instanceObject.localisedStyleMapFamilyName.keys())
             languageCodes.sort()
             for code in languageCodes:
                 if code == "en": continue

--- a/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorSettings.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorSettings.py
@@ -46,7 +46,10 @@ class Settings(BaseWindowController):
 
         self.w.closeButton = Button((-190, y, -110, 20), "Cancel", callback=self.closeCallback, sizeStyle="small")
         self.w.closeButton.bind(".", ["command"])
-        self.w.closeButton.bind(unichr(27), [])
+        try:
+            escChar = unichr(27)
+        except: escChar = chr(27)
+        self.w.closeButton.bind(escChar, [])
 
         self.w.resetButton = Button((-280, y, -200, 20), "Reset", callback=self.resetCallback, sizeStyle="small")
 

--- a/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorwindow.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorwindow.py
@@ -1266,9 +1266,9 @@ class DesignSpaceEditor(BaseWindowController):
                 options[thisFileDir] = True
         if len(options)==1:
             # neat and tidy, all masters in a folder
-            return options.keys()[0]
+            return list(options.keys())[0]
         if options:
-            paths = options.keys()
+            paths = list(options.keys())
             paths.sort()
             return paths[0]
         return None
@@ -1729,7 +1729,7 @@ class DesignSpaceEditor(BaseWindowController):
         # add the open fonts
         weHave = [s.path for s in self.doc.sources]
         for f in AllFonts():
-            if f.path not in weHave:
+            if f.path and f.path not in weHave:
                 self.addSourceFromFont(f)
         self.enableInstanceList()
         self.validate()


### PR DESCRIPTION
— Turns dictionary keys into lists before sorting
— Makes the escape key binding compatible for Python 2 and 3
— Only adds fonts if they're saved (otherwise you get a crash)