### PR TITLE
Python 3 fix for unichr() and a fix to skip loading unsaved open fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 automatic_testfonts
 *.pyc
 DesignSpaceEditor.roboFontExt/lib/.pytest_cache
+.DS_Store

--- a/DesignSpaceEditor.roboFontExt/info.plist
+++ b/DesignSpaceEditor.roboFontExt/info.plist
@@ -40,6 +40,6 @@
 	<key>timeStamp</key>
 	<real>1531168218.27</real>
 	<key>version</key>
-	<string>1.6</string>
+	<string>1.7</string>
 </dict>
 </plist>

--- a/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorSettings.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorSettings.py
@@ -46,7 +46,10 @@ class Settings(BaseWindowController):
 
         self.w.closeButton = Button((-190, y, -110, 20), "Cancel", callback=self.closeCallback, sizeStyle="small")
         self.w.closeButton.bind(".", ["command"])
-        self.w.closeButton.bind(unichr(27), [])
+        try:
+            escChar = unichr(27)
+        except: escChar = chr(27)
+        self.w.closeButton.bind(escChar, [])
 
         self.w.resetButton = Button((-280, y, -200, 20), "Reset", callback=self.resetCallback, sizeStyle="small")
 

--- a/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorwindow.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designSpaceEditorwindow.py
@@ -1964,7 +1964,7 @@ class DesignSpaceEditor(BaseWindowController):
         # add the open fonts
         weHave = [s.path for s in self.doc.sources]
         for f in AllFonts():
-            if f.path not in weHave:
+            if f.path and f.path not in weHave:
                 self.addSourceFromFont(f)
         self.enableInstanceList()
         self.validate()


### PR DESCRIPTION
There was a separate PR, #6 , which looks like some of the fixes were remade manually but a few remaining fixes didn't get merged in. Leaving them here if you want them!