### PR TITLE
Bugfix - plistlib uses `load` since Python 3.4, `readPlist` is deprecated

### DIFF
--- a/DesignSpaceEditor.roboFontExt/info.plist
+++ b/DesignSpaceEditor.roboFontExt/info.plist
@@ -38,8 +38,8 @@
 	<key>requiresVersionMinor</key>
 	<string>3</string>
 	<key>timeStamp</key>
-	<real>1681461774.961129</real>
+	<real>1684533376.88781</real>
 	<key>version</key>
-	<string>1.9.9</string>
+	<string>1.9.10</string>
 </dict>
 </plist>

--- a/DesignSpaceEditor.roboFontExt/lib/designspaceProblems/__init__.py
+++ b/DesignSpaceEditor.roboFontExt/lib/designspaceProblems/__init__.py
@@ -33,7 +33,9 @@ def getUFOLayers(ufoPath):
     # </plist>
     layercontentsPath = os.path.join(ufoPath, "layercontents.plist")
     if os.path.exists(layercontentsPath):
-        p = plistlib.readPlist(layercontentsPath)
+        with open(layercontentsPath, "rb") as f:
+            p = plistlib.load(f)
+        
         return [a for a, b in p]
     return []
 

--- a/extensionLib/designspaceProblems/__init__.py
+++ b/extensionLib/designspaceProblems/__init__.py
@@ -33,7 +33,9 @@ def getUFOLayers(ufoPath):
     # </plist>
     layercontentsPath = os.path.join(ufoPath, "layercontents.plist")
     if os.path.exists(layercontentsPath):
-        p = plistlib.readPlist(layercontentsPath)
+        with open(layercontentsPath, "rb") as f:
+            p = plistlib.load(f)
+        
         return [a for a, b in p]
     return []
 


### PR DESCRIPTION
Hi @LettError,

I was trying to load up a DS with a support layer and got an error about `readPlist`, which has been deprecated since Python 3.4 and removed in 3.9. I updated to use `load` as is now the recommended method.

I rebuilt the ext and bumped the version to 1.9.10