### PR TITLE
Cross Extension Support

### DIFF
--- a/DesignspaceEditor2.roboFontExt/info.plist
+++ b/DesignspaceEditor2.roboFontExt/info.plist
@@ -24,6 +24,6 @@
 	<key>timeStamp</key>
 	<real>1653936779.9141068</real>
 	<key>version</key>
-	<string>2.6</string>
+	<string>2.7</string>
 </dict>
 </plist>

--- a/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
+++ b/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
@@ -31,6 +31,17 @@ from designspaceEditor.locationPreview import LocationPreview
 from designspaceEditor.designspaceSubscribers import registerOperator, unregisterOperator
 from designspaceEditor import extensionIdentifier
 
+try:
+    import prepolator
+    has_prepolator = True
+except ImportError:
+    has_prepolator = False
+
+try:
+    import batch
+    has_batch = True
+except ImportError:
+    has_batch = False
 
 designspaceBundle = ExtensionBundle("DesignspaceEditor2")
 
@@ -939,6 +950,26 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
             selectable=True,
             visibleByDefault=tabItem not in ["Notes"],
         ) for tabItem in self.tabItems]
+
+        if has_prepolator:
+            toolbarItems.append(
+                dict(
+                    itemIdentifier="prepolator",
+                    label="Prepolator",
+                    callback=self.toolbarPrepolator,
+                    imageObject=symbolImage("hand.point.up.braille", (1, 0, 1, 1))
+                    )
+                )
+
+        if has_batch:
+            toolbarItems.append(
+                dict(
+                    itemIdentifier="batch",
+                    label="Batch",
+                    callback=self.toolbarBatch,
+                    imageObject=symbolImage("square.and.arrow.up", (1, 0, 1, 1))
+                    )
+                )
 
         toolbarItems.extend([
             dict(itemIdentifier=AppKit.NSToolbarSpaceItemIdentifier),
@@ -2008,6 +2039,12 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
         return True
 
     # toolbar
+    
+    def toolbarPrepolator(self, sender):
+        prepolator.OpenPrepolator(ufoOperator=self.operator)
+
+    def toolbarBatch(self, sender):
+        batch.BatchController([self.operator.path])
 
     def toolbarSelectTab(self, sender):
         selectedTab = sender.label()

--- a/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
+++ b/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
@@ -951,6 +951,10 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
             visibleByDefault=tabItem not in ["Notes"],
         ) for tabItem in self.tabItems]
 
+        toolbarItems.append(
+            dict(itemIdentifier=AppKit.NSToolbarSpaceItemIdentifier),
+            )
+
         if has_prepolator:
             toolbarItems.append(
                 dict(
@@ -972,8 +976,6 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
                 )
 
         toolbarItems.extend([
-            dict(itemIdentifier=AppKit.NSToolbarSpaceItemIdentifier),
-
             dict(
                 itemIdentifier="preview",
                 label="Preview",
@@ -1008,6 +1010,13 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
             # ),
         ])
         self.w.addToolbar("DesignSpaceToolbar", toolbarItems, addStandardItems=False)
+        
+        items = self.w.getToolbarItems()
+        if "batch" in items:
+            items["batch"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
+        if "prepolator" in items:
+            items["prepolator"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
+
 
         # AXES
         axesToolsSsegmentDescriptions = [

--- a/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
+++ b/DesignspaceEditor2.roboFontExt/lib/designspaceEditor/ui.py
@@ -31,18 +31,6 @@ from designspaceEditor.locationPreview import LocationPreview
 from designspaceEditor.designspaceSubscribers import registerOperator, unregisterOperator
 from designspaceEditor import extensionIdentifier
 
-try:
-    import prepolator
-    has_prepolator = True
-except ImportError:
-    has_prepolator = False
-
-try:
-    import batch
-    has_batch = True
-except ImportError:
-    has_batch = False
-
 designspaceBundle = ExtensionBundle("DesignspaceEditor2")
 
 registeredAxisTags = [
@@ -951,31 +939,9 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
             visibleByDefault=tabItem not in ["Notes"],
         ) for tabItem in self.tabItems]
 
-        toolbarItems.append(
-            dict(itemIdentifier=AppKit.NSToolbarSpaceItemIdentifier),
-            )
-
-        if has_prepolator:
-            toolbarItems.append(
-                dict(
-                    itemIdentifier="prepolator",
-                    label="Prepolator",
-                    callback=self.toolbarPrepolator,
-                    imageObject=symbolImage("hand.point.up.braille", (1, 0, 1, 1))
-                    )
-                )
-
-        if has_batch:
-            toolbarItems.append(
-                dict(
-                    itemIdentifier="batch",
-                    label="Batch",
-                    callback=self.toolbarBatch,
-                    imageObject=symbolImage("square.and.arrow.up", (1, 0, 1, 1))
-                    )
-                )
-
         toolbarItems.extend([
+            dict(itemIdentifier=AppKit.NSToolbarSpaceItemIdentifier,
+            ),
             dict(
                 itemIdentifier="preview",
                 label="Preview",
@@ -1010,13 +976,12 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
             # ),
         ])
         self.w.addToolbar("DesignSpaceToolbar", toolbarItems, addStandardItems=False)
-        
+
         items = self.w.getToolbarItems()
         if "batch" in items:
             items["batch"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
         if "prepolator" in items:
             items["prepolator"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
-
 
         # AXES
         axesToolsSsegmentDescriptions = [
@@ -1243,6 +1208,47 @@ class DesignspaceEditorController(Subscriber, WindowController, BaseNotification
         self.observeNotifications()
 
     def started(self):
+        # moving import tests here to ensure loading
+        try:
+            import prepolator
+            has_prepolator = True
+        except ImportError:
+            has_prepolator = False
+
+        try:
+            import batch
+            has_batch = True
+        except ImportError:
+            has_batch = False
+
+        if has_prepolator:
+            self.w.addToolbarItem(
+                dict(
+                    itemIdentifier="prepolator",
+                    label="Prepolator",
+                    callback=self.toolbarPrepolator,
+                    imageObject=symbolImage("atom", (1, 0, 1, 1))
+                    ),
+                -3
+                )
+
+        if has_batch:
+            self.w.addToolbarItem(
+                dict(
+                    itemIdentifier="batch",
+                    label="Batch",
+                    callback=self.toolbarBatch,
+                    imageObject=symbolImage("arrow.right.filled.filter.arrow.right", (1, 0, 1, 1))
+                    ),
+                -3
+                )
+
+        items = self.w.getToolbarItems()
+        if "batch" in items:
+            items["batch"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
+        if "prepolator" in items:
+            items["prepolator"].setVisibilityPriority_(AppKit.NSToolbarItemVisibilityPriorityLow)
+
         with SendNotification(action="OpenDesignspace", designspace=self.operator):
             self.w.open()
         registerOperator(self.operator)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 DesignSpaceEditor2
 ==================
 
+A fork of DSE2 that adds a button access Prepolator and Batch with the current designspace object.
+If these extensions are not installed, nothing will change.
+
 Create and edit designspaces with Robofont 4.5+, with support for scripting.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 DesignSpaceEditor2
 ==================
 
-A fork of DSE2 that adds a button access Prepolator and Batch with the current designspace object.
-If these extensions are not installed, nothing will change.
-
 Create and edit designspaces with Robofont 4.5+, with support for scripting.
 
 ## Documentation


### PR DESCRIPTION
Hey, I wrote this for myself but thought others might benefit from this too. I think that RF could benefit from more cross-extension support within its tooling, just my opinion:)
It just adds a button in the toolbar to access prepolator and/or batch with current designspace object.